### PR TITLE
Propagate terminal resize metrics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+src/* linguist-vendored
+package.json linguist-vendored
+package-lock.json linguist-vendored
+media/* linguist-vendored

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -27,25 +27,20 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
+            native/target
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Cargo fmt
-        working-directory: native
-        run: cargo fmt --all -- --check
+        run: cargo fmt --all --manifest-path native/Cargo.toml -- --check
       - name: Cargo clippy
-        working-directory: native
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --manifest-path native/Cargo.toml -- -D warnings
       - name: Cargo test
-        working-directory: native
-        run: cargo test --workspace
+        run: cargo test --workspace --manifest-path native/Cargo.toml
       - name: Build ptyd
-        working-directory: native
-        run: cargo build --release -p ptyd --target ${{ matrix.target }}
+        run: cargo build --release --manifest-path native/Cargo.toml -p ptyd --target ${{ matrix.target }}
       - name: Smoke PTY (bounded)
-        working-directory: native
         shell: bash
         run: |
-          BIN="target/${{ matrix.target }}/release/ptyd"
+          BIN="native/target/${{ matrix.target }}/release/ptyd"
           printf '%s\n' \
             '{"t":"i","data":"ZWNobyBvaw0K"}' \
             '{"t":"i","data":"ZXhpdA0K"}' \
@@ -53,15 +48,13 @@ jobs:
           grep -q '"t":"o"' /tmp/ptyd.out
           grep -q '"t":"x"' /tmp/ptyd.out
       - name: Build app
-        working-directory: native
-        run: cargo build --release --manifest-path app/Cargo.toml --target ${{ matrix.target }}
+        run: cargo build --release --manifest-path native/Cargo.toml -p app --target ${{ matrix.target }}
       - name: Package
-        working-directory: native
         run: |
-          out="target/${{ matrix.target }}/release"
-          mkdir -p dist/${{ matrix.artifact }}
-          cp "$out/app" dist/${{ matrix.artifact }}/
-          rsync -a app/assets/ dist/${{ matrix.artifact }}/assets/
+          out="native/target/${{ matrix.target }}/release"
+          mkdir -p native/dist/${{ matrix.artifact }}
+          cp "$out/app" native/dist/${{ matrix.artifact }}/
+          rsync -a native/app/assets/ native/dist/${{ matrix.artifact }}/assets/
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ unzip app-macos-*.zip
 ```bash
 git clone https://github.com/3xecutablefile/terminal-ui.git
 cd terminal-ui
-cargo build --release -p app
-sudo ln -sf "$(pwd)/target/release/app" /usr/local/bin/terminal-ui
+cargo build --release --manifest-path native/Cargo.toml -p app
+sudo ln -sf "$(pwd)/native/target/release/app" /usr/local/bin/terminal-ui
 
 # verify the shortcut
 terminal-ui --version
@@ -81,18 +81,18 @@ terminal-ui --version
 
 ```bash
 # in repo root
-cargo build --release -p app
-./target/release/app   # run (path varies per OS)
+cargo build --release --manifest-path native/Cargo.toml -p app
+./native/target/release/app   # run (path varies per OS)
 ```
 
 ### Cross-platform targets (examples)
 
 ```bash
 # Linux x64
-cargo build --release -p app --target x86_64-unknown-linux-gnu
+cargo build --release --manifest-path native/Cargo.toml -p app --target x86_64-unknown-linux-gnu
 
 # macOS x64
-cargo build --release -p app --target x86_64-apple-darwin
+cargo build --release --manifest-path native/Cargo.toml -p app --target x86_64-apple-darwin
 ```
 
 ---

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -55,41 +55,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alacritty_config"
-version = "0.2.3-rc1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddc285ec4e416841550c49e551912c082ba16227361b65b204299a4d4d4453b"
-dependencies = [
- "log",
- "serde",
- "toml 0.9.5",
-]
-
-[[package]]
-name = "alacritty_terminal"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bccc2e60c2112dc8e8a722d6d30f2bb1a6a7b5d0e65fa695e09e57415dca7f7"
-dependencies = [
- "base64 0.22.1",
- "bitflags 2.9.3",
- "home",
- "libc",
- "log",
- "miow",
- "parking_lot",
- "piper",
- "polling",
- "regex-automata",
- "rustix-openpty",
- "serde",
- "signal-hook",
- "unicode-width",
- "vte",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,8 +103,6 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 name = "app"
 version = "0.1.0"
 dependencies = [
- "alacritty_config",
- "alacritty_terminal",
  "anyhow",
  "crossbeam-channel",
  "csscolorparser",
@@ -153,7 +116,9 @@ dependencies = [
  "swash",
  "sysinfo",
  "thiserror 1.0.69",
- "toml 0.8.23",
+ "toml",
+ "unicode-width",
+ "vte",
  "wgpu",
  "winit",
 ]
@@ -178,12 +143,6 @@ checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
  "libloading 0.7.4",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -213,12 +172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,9 +197,6 @@ name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "block"
@@ -353,15 +303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,12 +395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cursor-icon"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
-
-[[package]]
 name = "d3d12"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,12 +481,6 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -656,12 +585,6 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "getrandom"
@@ -956,12 +879,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,9 +893,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "malloc_buf"
@@ -1056,15 +970,6 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "miow"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044"
-dependencies = [
  "windows-sys 0.48.0",
 ]
 
@@ -1387,23 +1292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,20 +1308,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1504,7 +1378,7 @@ name = "ptyd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64",
  "nix 0.27.1",
  "portable-pty",
  "serde",
@@ -1674,34 +1548,9 @@ checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.9.3",
  "errno",
- "itoa",
  "libc",
- "linux-raw-sys 0.4.15",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
-dependencies = [
- "bitflags 2.9.3",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "rustix-openpty"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25c3aad9fc1424eb82c88087789a7d938e1829724f3e4043163baf0d13cfc12"
-dependencies = [
- "errno",
- "libc",
- "rustix 0.38.44",
 ]
 
 [[package]]
@@ -1783,15 +1632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serial2"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,25 +1663,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "simd-adler32"
@@ -2065,24 +1886,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
-dependencies = [
- "indexmap 2.11.0",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.13",
 ]
 
 [[package]]
@@ -2095,22 +1901,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.11.0",
- "toml_datetime 0.6.11",
+ "toml_datetime",
  "winnow 0.5.40",
 ]
 
@@ -2122,18 +1919,9 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.11.0",
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_write",
- "winnow 0.7.13",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
-dependencies = [
  "winnow 0.7.13",
 ]
 
@@ -2142,12 +1930,6 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "toml_writer"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "ttf-parser"
@@ -2203,10 +1985,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a0b683b20ef64071ff03745b14391751f6beab06a54347885459b77a3f2caa5"
 dependencies = [
- "bitflags 2.9.3",
- "cursor-icon",
- "log",
- "serde",
+ "arrayvec",
  "utf8parse",
  "vte_generate_state_changes",
 ]
@@ -2497,7 +2276,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.44",
+ "rustix",
 ]
 
 [[package]]

--- a/native/app/Cargo.toml
+++ b/native/app/Cargo.toml
@@ -12,8 +12,6 @@ wgpu = "0.17"
 pollster = "0.3"
 crossbeam-channel = "0.5"
 ptycore = { path = "../ptycore" }
-alacritty_terminal = { version = "0.25", default-features = false, features = ["serde"] }
-alacritty_config   = { version = "0.2.3-rc1", default-features = false }
 swash = "0.1"
 fontdb = "0.16"
 thiserror = "1"
@@ -21,6 +19,11 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 dirs = "6"
 csscolorparser = "0.6"
-sysinfo = "0.30"
+# Terminal emulation & text handling
+vte = "0.13"
+unicode-width = "0.1"
+# System panels (use multithread to avoid blocking)
+sysinfo = { version = "0.30", features = ["multithread"] }
 
-[build-dependencies]
+[features]
+default = []

--- a/native/app/src/lib.rs
+++ b/native/app/src/lib.rs
@@ -1,0 +1,6 @@
+//! Library façade so tests and tools can import modules without bin-only quirks.
+#![allow(clippy::needless_return, clippy::new_without_default)]
+pub mod gfx;
+pub mod term;
+pub mod theme;
+pub mod ui;

--- a/native/app/src/main.rs
+++ b/native/app/src/main.rs
@@ -30,6 +30,9 @@ struct State {
     theme: theme::Theme,
     switcher: ThemeSwitcher,
     panels: Panels,
+    cell_width: f64,
+    cell_height: f64,
+    scale_factor: f64,
 }
 
 impl State {
@@ -79,11 +82,15 @@ impl State {
         });
         let pty = Arc::new(Mutex::new(handle));
 
-        let emu = Emu::new(cols, rows);
+        let emu = Emu::new(cols as usize, rows as usize);
         let renderer = Renderer::new();
         let theme = theme::load_theme("tron")?;
         let switcher = ThemeSwitcher::new();
         let panels = Panels::new();
+
+        let scale_factor = window.scale_factor();
+        let cell_width = size.width as f64 / cols as f64;
+        let cell_height = size.height as f64 / rows as f64;
 
         Ok(Self {
             surface,
@@ -98,17 +105,31 @@ impl State {
             theme,
             switcher,
             panels,
+            cell_width,
+            cell_height,
+            scale_factor,
         })
     }
 
-    fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
+    fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>, scale_factor: Option<f64>) {
         if new_size.width > 0 && new_size.height > 0 {
+            if let Some(sf) = scale_factor {
+                let ratio = sf / self.scale_factor;
+                self.scale_factor = sf;
+                self.cell_width *= ratio;
+                self.cell_height *= ratio;
+            }
             self.size = new_size;
             self.config.width = new_size.width;
             self.config.height = new_size.height;
             self.surface.configure(&self.device, &self.config);
             self.renderer.resize(new_size.width, new_size.height);
-            self.emu.resize(0, 0);
+            let cols = (new_size.width as f64 / self.cell_width).floor().max(1.0) as u16;
+            let rows = (new_size.height as f64 / self.cell_height).floor().max(1.0) as u16;
+            if let Ok(mut pty) = self._pty.lock() {
+                let _ = pty.resize(cols, rows);
+            }
+            self.emu.resize(cols as usize, rows as usize);
         }
     }
 
@@ -159,9 +180,9 @@ impl State {
 
     fn update(&mut self) {
         while let Ok(bytes) = self.rx.try_recv() {
-            self.emu.feed(&bytes);
+            self.emu.on_bytes(&bytes);
         }
-        self.panels.update();
+        self.panels.tick();
     }
 
     fn render(&mut self) -> Result<(), SurfaceError> {
@@ -202,7 +223,7 @@ impl State {
             64.0,
             pw - 48.0,
             16.0,
-            self.panels.cpu_use,
+            self.panels.cpu_percent,
             "CPU",
             &self.theme,
         );
@@ -212,7 +233,7 @@ impl State {
             112.0,
             pw - 48.0,
             16.0,
-            self.panels.mem_use,
+            self.panels.mem_percent,
             "RAM",
             &self.theme,
         );
@@ -255,10 +276,12 @@ fn main() -> Result<()> {
                 if !state.input(&event) {
                     match event {
                         WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
-                        WindowEvent::Resized(size) => state.resize(size),
-                        WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                            state.resize(*new_inner_size)
-                        }
+                        WindowEvent::Resized(size) => state.resize(size, None),
+                        WindowEvent::ScaleFactorChanged {
+                            new_inner_size,
+                            scale_factor,
+                            ..
+                        } => state.resize(*new_inner_size, Some(scale_factor)),
                         _ => {}
                     }
                 }
@@ -267,7 +290,7 @@ fn main() -> Result<()> {
                 state.update();
                 match state.render() {
                     Ok(_) => {}
-                    Err(wgpu::SurfaceError::Lost) => state.resize(state.size),
+                    Err(wgpu::SurfaceError::Lost) => state.resize(state.size, None),
                     Err(wgpu::SurfaceError::OutOfMemory) => *control_flow = ControlFlow::Exit,
                     Err(e) => eprintln!("render error: {e:?}"),
                 }

--- a/native/app/src/term/emu.rs
+++ b/native/app/src/term/emu.rs
@@ -1,13 +1,174 @@
-#[allow(dead_code)]
-pub struct Emu;
+use std::cmp::{max, min};
+use unicode_width::UnicodeWidthChar;
+use vte::{Params, Parser, Perform};
 
 #[allow(dead_code)]
+#[derive(Clone, Copy, Default)]
+pub struct Rgba(pub u8, pub u8, pub u8, pub u8);
+
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+pub struct Cell {
+    pub ch: char,
+    pub fg: Rgba,
+    pub bg: Rgba,
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self {
+            ch: ' ',
+            fg: Rgba(0xD6, 0xEF, 0xFF, 0xFF),
+            bg: Rgba(0x07, 0x12, 0x1A, 0xFF),
+        }
+    }
+}
+
+pub struct Emu {
+    pub cols: usize,
+    pub rows: usize,
+    pub grid: Vec<Cell>,
+    pub cur_x: usize,
+    pub cur_y: usize,
+    parser: Parser,
+    cur_fg: Rgba,
+    cur_bg: Rgba,
+}
+
 impl Emu {
-    pub fn new(_cols: u16, _rows: u16) -> Self {
-        Emu
+    pub fn new(cols: usize, rows: usize) -> Self {
+        let cols = max(1, cols);
+        let rows = max(1, rows);
+        Self {
+            cols,
+            rows,
+            grid: vec![Cell::default(); cols * rows],
+            cur_x: 0,
+            cur_y: 0,
+            parser: Parser::new(),
+            cur_fg: Cell::default().fg,
+            cur_bg: Cell::default().bg,
+        }
     }
 
-    pub fn feed(&mut self, _bytes: &[u8]) {}
+    pub fn resize(&mut self, cols: usize, rows: usize) {
+        self.cols = max(1, cols);
+        self.rows = max(1, rows);
+        self.grid = vec![Cell::default(); self.cols * self.rows];
+        self.cur_x = 0;
+        self.cur_y = 0;
+    }
 
-    pub fn resize(&mut self, _cols: u16, _rows: u16) {}
+    #[inline]
+    fn idx(&self, x: usize, y: usize) -> usize {
+        y * self.cols + x
+    }
+
+    pub fn draw_char(&mut self, c: char) {
+        if c == '\n' {
+            self.cur_x = 0;
+            if self.cur_y + 1 >= self.rows {
+                self.scroll_up();
+            } else {
+                self.cur_y += 1;
+            }
+            return;
+        }
+        if c == '\r' {
+            self.cur_x = 0;
+            return;
+        }
+        if c == '\x08' {
+            // BS
+            if self.cur_x > 0 {
+                self.cur_x -= 1;
+            }
+            return;
+        }
+        if c.is_control() {
+            return;
+        }
+        let w = UnicodeWidthChar::width(c).unwrap_or(1).max(1);
+        if self.cur_x + w > self.cols {
+            self.cur_x = 0;
+            if self.cur_y + 1 >= self.rows {
+                self.scroll_up();
+            } else {
+                self.cur_y += 1;
+            }
+        }
+        let i = self.idx(self.cur_x, self.cur_y);
+        self.grid[i] = Cell {
+            ch: c,
+            fg: self.cur_fg,
+            bg: self.cur_bg,
+        };
+        self.cur_x += w;
+    }
+
+    fn clear_all(&mut self) {
+        self.grid.fill(Cell::default());
+        self.cur_x = 0;
+        self.cur_y = 0;
+    }
+
+    fn scroll_up(&mut self) {
+        if self.rows <= 1 {
+            return;
+        }
+        let w = self.cols;
+        let len = self.grid.len();
+        self.grid.copy_within(w.., 0);
+        for c in self.grid[(len - w)..].iter_mut() {
+            *c = Cell::default();
+        }
+    }
+
+    /// Feed raw PTY bytes: use vte to parse ANSI and print UTF-8 safely.
+    pub fn on_bytes(&mut self, bytes: &[u8]) {
+        let mut parser = std::mem::take(&mut self.parser);
+        for &b in bytes {
+            parser.advance(self, b);
+        }
+        self.parser = parser;
+    }
+}
+
+impl Perform for Emu {
+    fn print(&mut self, c: char) {
+        self.draw_char(c);
+    }
+    fn execute(&mut self, byte: u8) {
+        match byte {
+            b'\n' => self.draw_char('\n'),
+            b'\r' => self.draw_char('\r'),
+            b'\x08' => self.draw_char('\x08'),
+            _ => {}
+        }
+    }
+    fn csi_dispatch(&mut self, params: &Params, _ints: &[u8], _ignore: bool, action: char) {
+        match action {
+            'H' | 'f' => {
+                let mut iter = params.iter();
+                let y = iter.next().and_then(|p| p.first()).copied().unwrap_or(1);
+                let x = iter.next().and_then(|p| p.first()).copied().unwrap_or(1);
+                let x = x.saturating_sub(1) as usize;
+                let y = y.saturating_sub(1) as usize;
+                self.cur_x = min(x, self.cols.saturating_sub(1));
+                self.cur_y = min(y, self.rows.saturating_sub(1));
+            }
+            'J' => {
+                if *params.iter().next().and_then(|p| p.first()).unwrap_or(&0) == 2 {
+                    self.clear_all();
+                }
+            }
+            'm' => {
+                if *params.iter().next().and_then(|p| p.first()).unwrap_or(&0) == 0 {
+                    self.cur_fg = Cell::default().fg;
+                    self.cur_bg = Cell::default().bg;
+                }
+            }
+            _ => {}
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- throttle panel sampling to reduce system load
- parse PTY output via vte for basic ANSI/UTF-8 support
- compute terminal cell geometry on window resize
- expose library facade and build native workspace explicitly
- document native workspace path in build instructions
- mark legacy JS folders as linguist-vendored so Rust dominates repo stats

## Testing
- `cargo fmt --all --manifest-path native/Cargo.toml -- --check`
- `cargo clippy --workspace --manifest-path native/Cargo.toml -- -D warnings`
- `cargo test --workspace --manifest-path native/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b5d16cc2c08323a15ce21624d35d67