### PR TITLE
Remove duplicate test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,15 +26,7 @@
     "postbuild-linux": "rm -R prebuild-src",
     "postbuild-darwin": "rm -R prebuild-src",
     "postbuild-windows": "rmdir /S /Q prebuild-src",
-
     "test": "npm install --ignore-scripts && snyk test",
-=======
-
-    "test": "npm install --ignore-scripts && rsync -a --info=progress2 src/ prebuild-src --exclude node_modules && node prebuild-minify.js && cd prebuild-src && npm install --ignore-scripts && snyk test && cd .. && rm -R prebuild-src",
-=======
-    "test": "rsync -a --info=progress2 src/ prebuild-src --exclude node_modules && node prebuild-minify.js && cd prebuild-src && npm install --ignore-scripts && snyk test && cd .. && rm -R prebuild-src",
-
-
     "init-file-icons": "git submodule update --init",
     "update-file-icons": "git submodule foreach git pull origin master && node file-icons-generator.js"
   },


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in package.json
- keep a single `test` script

## Testing
- `npm test` *(fails: Error: read ECONNRESET while downloading Snyk CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68c6beb7ed7c8323aa7755b1127a20a0