### PR TITLE
Ensure submodules checked out during build

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
@@ -39,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
       with:
@@ -80,6 +84,8 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
@@ -112,6 +118,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
## Summary
- make each `actions/checkout@v4` step fetch submodules in `build-binaries.yaml`

## Testing
- `npm test` *(fails: Invalid package.json JSONParseError)*
- `git submodule update --init --recursive file-icons/atom file-icons/bytesize-icons file-icons/devopicons file-icons/font-awesome file-icons/mfixx file-icons/source` *(fails: Could not read from remote repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c79477607c8323afdcc076b5c39184