### PR TITLE
Use HTTPS for bytesize-icons submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/FortAwesome/Font-Awesome.git
 [submodule "file-icons/bytesize-icons"]
 	path = file-icons/bytesize-icons
-	url = git@github.com:danklammer/bytesize-icons.git
+	url = https://github.com/danklammer/bytesize-icons.git


### PR DESCRIPTION
## Summary
- switch file-icons/bytesize-icons submodule to use HTTPS URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c79a09f6588323b709311f4a8829d4